### PR TITLE
Workaround to get counts based on search hits collection

### DIFF
--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -51,6 +51,7 @@ module Chewy
       alias_method :to_ary, :to_a
       alias_method :total_count, :total
       alias_method :total_entries, :total
+      alias_method :count, :total
 
       # The class is initialized with the list of chewy indexes and/or
       # types, which are later used to compose requests.
@@ -801,21 +802,6 @@ module Chewy
       end
 
       # @!group Additional actions
-
-      # Returns total count of hits for the request. If the request
-      # was already performed - it uses the `total` value, otherwise
-      # it executes a fast count request.
-      #
-      # @return [Integer] total hits count
-      def count
-        if performed?
-          total
-        else
-          Chewy.client.count(only(WHERE_STORAGES).render)['count']
-        end
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound
-        0
-      end
 
       # Checks if any of the document exist for this request. If
       # the request was already performed - it uses the `total`,

--- a/lib/chewy/search/response.rb
+++ b/lib/chewy/search/response.rb
@@ -19,7 +19,7 @@ module Chewy
         @hits ||= hits_root['hits'] || []
       end
 
-      # Response `total` field. Returns `0` if something went wrong.
+      # Amount of entries in raw response 'hits' collection.
       #
       # @return [Integer]
       def total

--- a/lib/chewy/search/response.rb
+++ b/lib/chewy/search/response.rb
@@ -23,7 +23,7 @@ module Chewy
       #
       # @return [Integer]
       def total
-        @total ||= hits_root['total'] || 0
+        @total ||= hits.count
       end
 
       # Response `max_score` field.


### PR DESCRIPTION
Update `Chewy::Search::Response#total` and `Chewy::Search::Request#count` to result with actual number of hits in response.

**Reason:**
Broken pagination when `total` number of `hits` differs from the size of `hits` collection
**Example:**
```ruby
result = AnyIndex.query(query_string: {query: 'query'})
result.response.instance_variable_get(:@body)
# =>
# {...
#  "hits" =>
#  {"total"=>26,
#   "hits"=>
#     [...10entries]
#    ...
#   }
# }
result.count # => 26
result.objects.count # => 10
results.objects.per(25).total_pages # => 2
```

**After fix**

```ruby
result = AnyIndex.query(query_string: {query: 'query'})
result.count # => 10
result.objects.count # => 10
results.objects.per(25).total_pages # => 1
```